### PR TITLE
fix: add playlist property to playlist tracks

### DIFF
--- a/lib/Extractor/Youtube.ts
+++ b/lib/Extractor/Youtube.ts
@@ -153,6 +153,7 @@ export class YoutubeiExtractor extends BaseExtractor<YoutubeiOptions> {
 							requestedBy: context.requestedBy,
 							url: `https://youtube.com/watch?v=${v.id}`,
 							raw: v,
+							playlist: pl,
 							source: "youtube",
 							queryType: "youtubeVideo",
 							metadata: v,


### PR DESCRIPTION
## Changes
Fixes an issue that caused playlist songs to not be added to the queue.

This issue happens when the user calls the play function with the first song from the playlist as a parameter instead of the playlist itself. 

Also fixes issues that might arise from not being able to access the playlist property on the tracks when the audioTracksAdd event is emitted.

## Status
- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.