### PR TITLE
Support playlists with more than 100 videos

### DIFF
--- a/lib/Extractor/Youtube.ts
+++ b/lib/Extractor/Youtube.ts
@@ -143,7 +143,15 @@ export class YoutubeiExtractor extends BaseExtractor<YoutubeiOptions> {
 					source: "youtube",
 				});
 
-				pl.tracks = (playlist.videos.filter((v) => v.type === "PlaylistVideo") as PlaylistVideo[]).map(
+				// gather videos from all playlist pages and push them into one list
+				const allVideos = [...playlist.videos];
+				let currentPage = playlist;
+				while (currentPage.has_continuation) {
+					currentPage = await currentPage.getContinuation();
+					allVideos.push(...currentPage.videos);
+				}
+
+				pl.tracks = (allVideos.filter((v) => v.type === "PlaylistVideo") as PlaylistVideo[]).map(
 					(v) =>
 						new Track(this.context.player, {
 							title: v.title.text ?? "UNKNOWN TITLE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-player-youtubei",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "An unofficial package to test the use of youtubei in discord-player v6.",
   "main": "dist/index.js",
   "repository": "https://github.com/retrouser955/discord-player-youtubei",


### PR DESCRIPTION
`youtubei.js` retrieves items from playlists in pages of 100 videos. The current code only processes the first 100 videos of a playlist, which becomes a problem for larger playlists.

This change addresses this by looping over the continuations in the Playlist object until there are no continuations remaining.