### PR TITLE
feat: fetch fallback

### DIFF
--- a/lib/common/generateYTStream.ts
+++ b/lib/common/generateYTStream.ts
@@ -29,7 +29,7 @@ export function createWebReadableStream(
   innertube: Innertube,
   videoInfo: VideoInfo,
 ) {
-  let [start, end] = [0, size || 1048576 * 10];
+  let [start, end] = [0, Math.min(size, 1048576 * 10) || 1048576 * 10];
   let isEnded = false;
 
   let abort: AbortController;

--- a/lib/utils/downloader/index.ts
+++ b/lib/utils/downloader/index.ts
@@ -57,11 +57,11 @@ export async function stream<T extends boolean = false>(
 
   if (!fmt.url || !fmt.content_length) throw Errors.NoDownload;
 
-  const downloadedUrl = `${fmt.url!}&cpn=${info.cpn}`;
+  const downloadedUrl = fmt.url!;
 
   const stream = skipStream
     ? null
-    : createWebReadableStream(downloadedUrl, fmt.content_length, yt);
+    : createWebReadableStream(downloadedUrl, fmt.content_length, yt, info);
 
   const readable = stream ? await createReadableFromWeb(stream) : null;
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@discord-player/extractor": "^7.1.0",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.7.5",
-    "bgutils-js": "^3.1.0",
     "discord-player": "^7.1.0",
     "discord.js": "^14.16.3",
     "googlevideo": "^3.0.0",
@@ -25,7 +24,8 @@
     "jsdom": "^26.0.0",
     "tiny-typed-emitter": "^2.1.0",
     "undici": "^7.1.0",
-    "youtubei.js": "^13.2.0"
+    "youtubei.js": "^13.2.0",
+    "bgutils-js": "^3.1.0"
   },
   "scripts": {
     "build": "npm run format && tsup",


### PR DESCRIPTION
Right now, there's an issue where if you only fetch the audio, you can only get about 40% of the full length of the source (at least on me). As a workaround, I proposed a fallback to fetch video+audio if the original option fail.