### PR TITLE
Use Innertube fetch in sabr stream configs

### DIFF
--- a/src/Streams/ServerAbrStream.ts
+++ b/src/Streams/ServerAbrStream.ts
@@ -31,6 +31,7 @@ export async function createSabrStream(video: YoutubeTrack): Promise<Readable | 
 
         if (videoData) {
             SabrStreamConfig = {
+                fetch: innertube.session.http.fetch_function,
                 formats: videoData.sabrFormat,
                 serverAbrStreamingUrl: videoData.url,
                 videoPlaybackUstreamerConfig: videoData.uStreamConfig,
@@ -67,6 +68,7 @@ export async function createSabrStream(video: YoutubeTrack): Promise<Readable | 
             const sabrFormats: SabrFormat[] = playerResponse.streaming_data?.adaptive_formats.map(buildSabrFormat) || [];
 
             SabrStreamConfig = {
+                fetch: innertube.session.http.fetch_function,
                 formats: sabrFormats,
                 serverAbrStreamingUrl,
                 videoPlaybackUstreamerConfig,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -44,6 +44,7 @@ export function getPlaylistId(url: string): playlistObj {
 export function createYoutubeFetch(options?: YoutubeOptions): any {
     const f: typeof fetch = (input: URL | RequestInfo, init: RequestInit): Promise<Response> => {
         if (options?.proxy) {
+            init ??= {};
             (init as any).dispatcher = options.proxy[Math.floor(Math.random() * options.proxy.length)];
         }
         return Platform.shim.fetch(input, init);


### PR DESCRIPTION
Fixes two issues I ran into with proxies:

1. When Innertube clients start up, they make some calls with an undefined `init`, which was causing errors when using proxies. If `init` is undefined, a new empty object is created and used to set the proxy dispatcher.
2. During `SabrStreamConfig` creation, use the fetch function defined in the Innertube client. This ensures that the streams are fetched using proxies if there are any set in the options.